### PR TITLE
:sparkles: feature (Anc Second Screening): Implemented multi-child su…

### DIFF
--- a/flourish_dashboard/model_wrappers/antenatal_enrollment_model_wrapper.py
+++ b/flourish_dashboard/model_wrappers/antenatal_enrollment_model_wrapper.py
@@ -9,4 +9,4 @@ class AntenatalEnrollmentModelWrapper(ModelWrapper):
     next_url_name = settings.DASHBOARD_URL_NAMES.get(
         'maternal_screening_listboard_url')
     next_url_attrs = ['screening_identifier']
-    querystring_attrs = ['subject_identifier', 'screening_identifier']
+    querystring_attrs = ['subject_identifier', 'child_subject_identifier']

--- a/flourish_dashboard/model_wrappers/antenatal_enrollment_wrapper_mixin.py
+++ b/flourish_dashboard/model_wrappers/antenatal_enrollment_wrapper_mixin.py
@@ -2,6 +2,7 @@ from django.apps import apps as django_apps
 from django.core.exceptions import ObjectDoesNotExist
 
 from .antenatal_enrollment_model_wrapper import AntenatalEnrollmentModelWrapper
+from ..utils import flourish_dashboard_utils
 
 
 class AntenatalEnrollmentModelWrapperMixin:
@@ -33,11 +34,14 @@ class AntenatalEnrollmentModelWrapperMixin:
                 self.consent_model_obj.caregiverchildconsent_set.all())
 
             for caregiver_child_consent in caregiver_child_consents:
-                model_obj = self.antenatal_enrollments_model_obj(
-                    caregiver_child_consent) or self.antenatal_enrollment_cls(
-                    **self.create_antenatal_enrollments_options(
-                        caregiver_child_consent))
-                wrapped_entries.append(AntenatalEnrollmentModelWrapper(model_obj))
+                if flourish_dashboard_utils.screening_object_by_child_pid(
+                        self.consent.screening_identifier,
+                        caregiver_child_consent.subject_identifier):
+                    model_obj = self.antenatal_enrollments_model_obj(
+                        caregiver_child_consent) or self.antenatal_enrollment_cls(
+                        **self.create_antenatal_enrollments_options(
+                            caregiver_child_consent))
+                    wrapped_entries.append(AntenatalEnrollmentModelWrapper(model_obj))
 
         return wrapped_entries
 

--- a/flourish_dashboard/model_wrappers/caregiver_child_consent_model_wrapper.py
+++ b/flourish_dashboard/model_wrappers/caregiver_child_consent_model_wrapper.py
@@ -58,6 +58,6 @@ class CaregiverChildConsentModelWrapper(CaregiverChildConsentModelWrapperMixin,
         """
         try:
             return self.maternal_delivery_cls.objects.get(
-                subject_identifier=self.object.subject_consent.subject_identifier)
+                child_subject_identifier=self.object.subject_identifier)
         except ObjectDoesNotExist:
             return None

--- a/flourish_dashboard/model_wrappers/child_assent_model_wrapper_mixin.py
+++ b/flourish_dashboard/model_wrappers/child_assent_model_wrapper_mixin.py
@@ -86,14 +86,14 @@ class ChildAssentModelWrapperMixin:
             """
 
             # set was used, to get care giver child consent in v1 or v2
-            caregiverchildconsents = self.consent_model_obj.caregiverchildconsent_set \
+            caregiver_child_consents = self.consent_model_obj.caregiverchildconsent_set \
                 .only('child_age_at_enrollment', 'is_eligible') \
                 .filter(is_eligible=True, child_age_at_enrollment__gte=7)
 
-            for caregiverchildconsent in caregiverchildconsents:
-                model_obj = self.child_assent_model_obj(caregiverchildconsent) or \
+            for caregiver_child_consent in caregiver_child_consents:
+                model_obj = self.child_assent_model_obj(caregiver_child_consent) or \
                             self.assent_model_cls(
-                                **self.create_child_assent_options(caregiverchildconsent))
+                                **self.create_child_assent_options(caregiver_child_consent))
                 # create options based on caregiverchildconsent, which is either
                 # version 1 or version 2
 
@@ -105,15 +105,15 @@ class ChildAssentModelWrapperMixin:
         exists_conditions = list()
 
         if getattr(self, 'consent_model_obj', None):
-            caregiverchildconsents = self.consent_model_obj.caregiverchildconsent_set \
+            caregiver_child_consents = self.consent_model_obj.caregiverchildconsent_set \
                 .only('child_age_at_enrollment', 'is_eligible') \
                 .filter(is_eligible=True,
                         child_age_at_enrollment__gte=7,
                         child_age_at_enrollment__lt=18)
 
-            for caregiver_childconsent in caregiverchildconsents:
+            for caregiver_child_consent in caregiver_child_consents:
                 model_objs = ChildAssent.objects.filter(
-                    subject_identifier=caregiver_childconsent.subject_identifier).exists()
+                    subject_identifier=caregiver_child_consent.subject_identifier).exists()
                 exists_conditions.append(model_objs)
 
             return all(exists_conditions)

--- a/flourish_dashboard/model_wrappers/child_dummy_consent_model_wrapper_mixin.py
+++ b/flourish_dashboard/model_wrappers/child_dummy_consent_model_wrapper_mixin.py
@@ -49,12 +49,12 @@ class ChildDummyConsentModelWrapperMixin:
 
     @property
     def child_name_initial(self):
+        childconsent = self.child_consent
         if self.get_assent:
             name = self.get_assent.first_name
             initials = self.get_assent.initials
             return f'{name} {initials}'
-        else:
-            childconsent = self.child_consent
+        elif childconsent:
             first_name = childconsent.first_name
             last_name = childconsent.last_name
             if first_name and last_name:
@@ -63,12 +63,12 @@ class ChildDummyConsentModelWrapperMixin:
 
     @property
     def child_age(self):
+        childconsent = self.child_consent
         if self.get_assent:
             birth_date = self.get_assent.dob
             years = age(birth_date, get_utcnow()).years
             return years
-        else:
-            childconsent = self.child_consent
+        elif childconsent:
             birth_date = childconsent.child_dob
             if birth_date:
                 years = age(birth_date, get_utcnow()).years
@@ -76,19 +76,19 @@ class ChildDummyConsentModelWrapperMixin:
 
     @property
     def gender(self):
+        childconsent = self.child_consent
         if self.get_assent:
             return self.get_assent.gender
-        else:
-            childconsent = self.child_consent
+        elif childconsent:
             return childconsent.gender
 
     @property
     def child_dob(self):
+        childconsent = self.child_consent
         if self.get_assent:
             birth_date = self.get_assent.dob
             return birth_date
-        else:
-            childconsent = self.child_consent
+        elif childconsent:
             birth_date = childconsent.child_dob
             return birth_date
 
@@ -112,7 +112,6 @@ class ChildDummyConsentModelWrapperMixin:
                 f"Enrollment Cohort is missing, {self.object.subject_identifier}")
         else:
             return cohort.name
-        return None
 
     @property
     def current_cohort(self):
@@ -127,10 +126,10 @@ class ChildDummyConsentModelWrapperMixin:
 
     @property
     def assent_date(self):
+        childconsent = self.child_consent
         if self.get_assent:
             return self.get_assent.consent_datetime.date()
-        else:
-            childconsent = self.child_consent
+        elif childconsent:
             consent_date = childconsent.consent_datetime.date()
             return consent_date
 

--- a/flourish_dashboard/model_wrappers/maternal_delivery_model_wrapper.py
+++ b/flourish_dashboard/model_wrappers/maternal_delivery_model_wrapper.py
@@ -3,9 +3,8 @@ from edc_model_wrapper import ModelWrapper
 
 
 class MaternalDeliveryModelWrapper(ModelWrapper):
-
     model = 'flourish_caregiver.maternaldelivery'
     next_url_name = settings.DASHBOARD_URL_NAMES.get(
         'subject_dashboard_url')
     next_url_attrs = ['subject_identifier']
-    querystring_attrs = ['subject_identifier']
+    querystring_attrs = ['subject_identifier', 'child_subject_identifier']

--- a/flourish_dashboard/model_wrappers/maternal_delivery_wrapper_mixin.py
+++ b/flourish_dashboard/model_wrappers/maternal_delivery_wrapper_mixin.py
@@ -2,6 +2,7 @@ from django.apps import apps as django_apps
 from django.core.exceptions import ObjectDoesNotExist
 
 from .maternal_delivery_model_wrapper import MaternalDeliveryModelWrapper
+from ..utils import flourish_dashboard_utils
 
 
 class MaternalDeliveryModelWrapperMixin:
@@ -22,11 +23,16 @@ class MaternalDeliveryModelWrapperMixin:
         """
         wrapped_entries = []
         for maternal_delivery in self.maternal_ultrasound_initial_obj:
-            model_obj = self.maternal_delivery_model_obj(
-                maternal_delivery.child_subject_identifier) or self.maternal_delivery_cls(
-                **self.create_maternal_delivery_options(
-                    maternal_delivery.child_subject_identifier))
-            wrapped_entries.append(self.maternal_delivery_model_wrapper_cls(model_obj))
+            if flourish_dashboard_utils.screening_object_by_child_pid(
+                    self.consent.screening_identifier,
+                    maternal_delivery.child_subject_identifier):
+                model_obj = (self.maternal_delivery_model_obj(
+                    maternal_delivery.child_subject_identifier) or
+                             self.maternal_delivery_cls(
+                                 **self.create_maternal_delivery_options(
+                                     maternal_delivery.child_subject_identifier)))
+                wrapped_entries.append(
+                    self.maternal_delivery_model_wrapper_cls(model_obj))
         return wrapped_entries
 
     @property

--- a/flourish_dashboard/model_wrappers/maternal_delivery_wrapper_mixin.py
+++ b/flourish_dashboard/model_wrappers/maternal_delivery_wrapper_mixin.py
@@ -5,45 +5,49 @@ from .maternal_delivery_model_wrapper import MaternalDeliveryModelWrapper
 
 
 class MaternalDeliveryModelWrapperMixin:
-
     maternal_delivery_model_wrapper_cls = MaternalDeliveryModelWrapper
 
-    @property
-    def maternal_delivery_model_obj(self):
+    def maternal_delivery_model_obj(self, child_subject_identifier):
         """Returns a maternal delivery model instance or None.
         """
         try:
-            return self.maternal_delivery_cls.objects.get(**self.maternal_delivery_options)
+            return self.maternal_delivery_cls.objects.get(
+                **self.maternal_delivery_options(child_subject_identifier))
         except ObjectDoesNotExist:
             return None
 
     @property
-    def maternal_delivery(self):
+    def maternal_deliveries(self):
         """Returns a wrapped saved or unsaved maternal del.
         """
-        model_obj = self.maternal_delivery_model_obj or self.maternal_delivery_cls(
-            **self.create_maternal_delivery_options)
-        return self.maternal_delivery_model_wrapper_cls(model_obj=model_obj)
+        wrapped_entries = []
+        for maternal_delivery in self.maternal_ultrasound_initial_obj:
+            model_obj = self.maternal_delivery_model_obj(
+                maternal_delivery.child_subject_identifier) or self.maternal_delivery_cls(
+                **self.create_maternal_delivery_options(
+                    maternal_delivery.child_subject_identifier))
+            wrapped_entries.append(self.maternal_delivery_model_wrapper_cls(model_obj))
+        return wrapped_entries
 
     @property
     def maternal_delivery_cls(self):
         return django_apps.get_model('flourish_caregiver.maternaldelivery')
 
-    @property
-    def create_maternal_delivery_options(self):
+    def create_maternal_delivery_options(self, child_subject_identifier):
         """Returns a dictionary of options to create a new
         unpersisted maternal delivery model instance.
         """
         options = dict(
+            child_subject_identifier=child_subject_identifier,
             subject_identifier=self.object.subject_identifier)
         return options
 
-    @property
-    def maternal_delivery_options(self):
+    def maternal_delivery_options(self, child_subject_identifier):
         """Returns a dictionary of options to get an existing
         maternal delivery model instance.
         """
         options = dict(
+            child_subject_identifier=child_subject_identifier,
             subject_identifier=self.object.subject_identifier)
         return options
 
@@ -51,8 +55,5 @@ class MaternalDeliveryModelWrapperMixin:
     def maternal_ultrasound_initial_obj(self):
         ultrasound_initial_cls = django_apps.get_model(
             'flourish_caregiver.ultrasound')
-        try:
-            return ultrasound_initial_cls.objects.get(
-                maternal_visit__subject_identifier=self.object.subject_identifier)
-        except ObjectDoesNotExist:
-            return None
+        return ultrasound_initial_cls.objects.filter(
+            maternal_visit__subject_identifier=self.object.subject_identifier)

--- a/flourish_dashboard/model_wrappers/maternal_screening_model_wrapper.py
+++ b/flourish_dashboard/model_wrappers/maternal_screening_model_wrapper.py
@@ -14,8 +14,7 @@ from .consent_model_wrapper_mixin import ConsentModelWrapperMixin
 from .subject_consent_model_wrapper import SubjectConsentModelWrapper
 
 
-class MaternalScreeningModelWrapper(AntenatalEnrollmentModelWrapperMixin,
-                                    CaregiverLocatorModelWrapperMixin,
+class MaternalScreeningModelWrapper(CaregiverLocatorModelWrapperMixin,
                                     ConsentModelWrapperMixin,
                                     ChildAssentModelWrapperMixin,
                                     BHPPriorScreeningModelWrapperMixin,
@@ -25,7 +24,7 @@ class MaternalScreeningModelWrapper(AntenatalEnrollmentModelWrapperMixin,
     querystring_attrs = ['screening_identifier']
     next_url_name = settings.DASHBOARD_URL_NAMES.get(
         'maternal_screening_listboard_url')
-    next_url_attrs = ['screening_identifier', 'subject_identifier', ]
+    next_url_attrs = ['screening_identifier', ]
 
     @property
     def consent_version_cls(self):

--- a/flourish_dashboard/model_wrappers/subject_consent_model_wrapper.py
+++ b/flourish_dashboard/model_wrappers/subject_consent_model_wrapper.py
@@ -3,10 +3,9 @@ from itertools import chain
 from django.apps import apps as django_apps
 from django.conf import settings
 from edc_model_wrapper import ModelWrapper
-
-from edc_odk.model_wrappers import LabResultsModelWrapperMixin, \
-    OmangCopiesModelWrapperMixin, NoteToFileModelWrapperMixin, \
-    AdultMainConsentModelWrapperMixin, ParentalConsentModelWrapperMixin
+from edc_odk.model_wrappers import AdultMainConsentModelWrapperMixin, \
+    LabResultsModelWrapperMixin, NoteToFileModelWrapperMixin, \
+    OmangCopiesModelWrapperMixin, ParentalConsentModelWrapperMixin
 
 from .antenatal_enrollment_wrapper_mixin import \
     AntenatalEnrollmentModelWrapperMixin
@@ -23,16 +22,17 @@ from .caregiver_locator_model_wrapper_mixin import \
 from .caregiver_offstudy_model_wrapper_mixin import \
     CaregiverOffstudyModelWrapperMixin
 from .child_assent_model_wrapper_mixin import ChildAssentModelWrapperMixin
-from .tb_adol_assent_model_wrapper_mixin import TbAdolChildAssentModelWrapperMixin
 from .consent_model_wrapper_mixin import ConsentModelWrapperMixin
+from .facet_model_wrapper_mixin import FacetModelWrapperMixin
 from .flourish_consent_version_model_wrapper_mixin import \
     FlourishConsentVersionModelWrapperMixin
 from .maternal_delivery_wrapper_mixin import MaternalDeliveryModelWrapperMixin
+from .tb_adol_assent_model_wrapper_mixin import TbAdolChildAssentModelWrapperMixin
 from .tb_adol_consent_model_wrapper_mixin import TbAdolConsentModelWrapperMixin
 from .tb_adol_screening_model_wrapper_mixin import TbAdolScreeningModelWrapperMixin
 from .tb_informed_consent_model_wrapper_mixin import TbInformedConsentModelWrapperMixin
 from .tb_offstudy_model_wrapper_mixin import TbOffstudyModelWrapperMixin
-from .facet_model_wrapper_mixin import FacetModelWrapperMixin
+
 
 class SubjectConsentModelWrapper(TbInformedConsentModelWrapperMixin,
                                  CaregiverContactModelWrapperMixin,
@@ -89,11 +89,12 @@ class SubjectConsentModelWrapper(TbInformedConsentModelWrapperMixin,
         unpersisted caregiver locator model instance.
         """
         options = dict(
-            screening_identifier=self.object.screening_identifier,)
+            screening_identifier=self.object.screening_identifier, )
         if self.assent_model_obj:
             options.update(
                 {
-                    'study_maternal_identifier': self.assent_model_obj.study_maternal_identifier
+                    'study_maternal_identifier':
+                        self.assent_model_obj.study_maternal_identifier
                 })
         else:
             options.update(
@@ -108,7 +109,8 @@ class SubjectConsentModelWrapper(TbInformedConsentModelWrapperMixin,
     def consent(self):
         """Returns a wrapped saved or unsaved consent.
 
-        Overriden from consent_mixin because it was used in numerous mixins but in this instance
+        Overriden from consent_mixin because it was used in numerous mixins, but in this
+        instance
         SubjectConsentModelWrapper is what is needed
         """
         model_obj = self.consent_model_obj or self.subject_consent_cls(
@@ -139,4 +141,3 @@ class SubjectConsentModelWrapper(TbInformedConsentModelWrapperMixin,
                     return True
                 else:
                     return False
-            return True

--- a/flourish_dashboard/templates/flourish_dashboard/buttons/antenatal_enrollment_button.html
+++ b/flourish_dashboard/templates/flourish_dashboard/buttons/antenatal_enrollment_button.html
@@ -1,14 +1,28 @@
- {% if preg_screening_obj %}
- <a id="antenatalenrollment_add_{{ subject_identifier }}" 
- 	title="{{ title }}"
+{% if wrapped_antenatal_enrollments %}
+    <div class="btn-group">
 
- 	{% if antenatal_enrollment_model_obj%}
-            class="btn btn-success btn-sm" data-toggle="tooltip"  data-placement="right"
-            href="{{ add_anternatal_enrollment_href }}">
-        {% else %}
-            class="btn btn-warning btn-sm" data-toggle="tooltip"  data-placement="right"
-        	href="{{ add_anternatal_enrollment_href }}">
-        {% endif %}
-     	Antenatal Enroll
- </a>
- {% endif %}
+        <button title="{{ title|default:'Antenatal Enrollments' }}" type="button"
+                class="btn {% if unsaved %} btn-warning {% else %} btn-success {% endif %} btn-sm dropdown-toggle"
+                data-toggle="dropdown">
+            {{ wrapped_antenatal_enrollments|length }} Child Antenatal Enrollment(s) <i class=""></i>
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+            <li class="dropdown-header">{{ title|default:'Antenatal Enrollments' }}</li>
+            {% for antenatal_enrollment in wrapped_antenatal_enrollments %}
+                <li>
+                    <a href="{{ antenatal_enrollment.get_absolute_url }}?next={{ antenatal_enrollment.next_url }}&{{ antenatal_enrollment.querystring }}">
+              			{% if antenatal_enrollment.id %}
+              				<small><i class="fa fa-check-circle" aria-hidden="true" style='color:green'></i></small>
+              			{% else %}
+              				<small><i class="fa fa-times-circle" aria-hidden="true" style='color:red'></i></small>
+              			{%endif%}
+                        <small>{{ antenatal_enrollment.child_subject_identifier }}</small>
+                    </a>
+
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+    <br>
+{% endif %}

--- a/flourish_dashboard/templates/flourish_dashboard/buttons/eligibility_button.html
+++ b/flourish_dashboard/templates/flourish_dashboard/buttons/eligibility_button.html
@@ -1,10 +1,11 @@
 <div class="btn-group">
-<a type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown">
-Not eligible <span class="caret"></span>
-</a>
-<ul class="dropdown-menu" role="menu">
-	{% for line in comment %}
-		<li><a href="#"><small>{{ line }}</small></a></li>
-	{% endfor %}
-</ul>
+    <a type="button" class="btn btn-sm btn-default dropdown-toggle"
+       data-toggle="dropdown">
+        Not eligible <span class="caret"></span>
+    </a>
+    <ul class="dropdown-menu" role="menu">
+        {% for line in comment %}
+            <li><a href="#"><small>{{ line }}</small></a></li>
+        {% endfor %}
+    </ul>
 </div>

--- a/flourish_dashboard/templates/flourish_dashboard/buttons/maternal_delivery_button.html
+++ b/flourish_dashboard/templates/flourish_dashboard/buttons/maternal_delivery_button.html
@@ -1,13 +1,28 @@
-<a id="maternaldelivery_add_{{ subject_identifier }}" 
- 	title="{{ title }}"
- 	{% if maternal_ultrasound_initial_obj %}
-	 	{% if maternal_delivery_model_obj %}
-	            class="btn btn-success btn-sm" data-toggle="tooltip"  data-placement="right"
-	            href="{{ add_maternal_delivery_href }}">
-	        {% else %}
-	            class="btn btn-warning btn-sm" data-toggle="tooltip"  data-placement="right"
-	        href="{{ add_maternal_delivery_href }}">
-	        {% endif %}
-	     	Maternal Delivery
-	{% endif %}
- </a>
+{% if wrapped_maternal_deliveries %}
+    <div class="btn-group">
+
+        <button title="{{ title|default:'Maternal Deliveries' }}" type="button"
+                class="btn {% if unsaved %} btn-warning {% else %} btn-success {% endif %} btn-sm dropdown-toggle"
+                data-toggle="dropdown">
+            {{ wrapped_maternal_deliveries|length }} Maternal Deliveries <i class=""></i>
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+            <li class="dropdown-header">{{ title|default:'Maternal Deliveries' }}</li>
+            {% for maternal_delivery in wrapped_maternal_deliveries %}
+                <li>
+                    <a href="{{ maternal_delivery.get_absolute_url }}?next={{ maternal_delivery.next_url }}&{{ maternal_delivery.querystring }}">
+              			{% if maternal_delivery.id %}
+              				<small><i class="fa fa-check-circle" aria-hidden="true" style='color:green'></i></small>
+              			{% else %}
+              				<small><i class="fa fa-times-circle" aria-hidden="true" style='color:red'></i></small>
+              			{%endif%}
+                        <small>{{ maternal_delivery.child_subject_identifier }}</small>
+                    </a>
+
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+    <br>
+{% endif %}

--- a/flourish_dashboard/templates/flourish_dashboard/maternal_subject/dashboard.html
+++ b/flourish_dashboard/templates/flourish_dashboard/maternal_subject/dashboard.html
@@ -11,7 +11,8 @@
    			<td>{% assents_button subject_consent %}</td>
             <td style="width: 5px"></td>
             <td>{% tb_adol_assents_button subject_consent %}</td>
-
+            <td>{% antenatal_enrollment_button subject_consent %}</td>
+            <td>{% maternal_delivery_button subject_consent %}</td>
    		</tr>
 	</table>
 

--- a/flourish_dashboard/templates/flourish_dashboard/maternal_subject/dashboard/special_forms.html
+++ b/flourish_dashboard/templates/flourish_dashboard/maternal_subject/dashboard/special_forms.html
@@ -17,12 +17,7 @@
     {% if screening_preg_women %}
         <tr>
             <td>
-                {% antenatal_enrollment_button subject_consent %}
-            </td>
-        </tr>
-        <tr>
-            <td>
-                {% maternal_delivery_button subject_consent %}
+                {% screening_button screening_preg_women %}
             </td>
         </tr>
     {% endif %}

--- a/flourish_dashboard/templates/flourish_dashboard/screening/maternal_listboard.html
+++ b/flourish_dashboard/templates/flourish_dashboard/screening/maternal_listboard.html
@@ -4,7 +4,8 @@
 {% load flourish_dashboard_extras %}
 
 {% block listboard_panel %}
-    <a id="maternal_screening_add" title="add screening" class="btn btn-sm btn-default" role="button"
+    <a id="maternal_screening_add" title="add screening" class="btn btn-sm btn-default"
+       role="button"
        href="{{ maternal_screening_add_url }}?next={{ maternal_screening_listboard_url }}">
         <i class="fa fa-plus fa-sm"></i>Add Antenatal Screening
     </a>
@@ -31,22 +32,13 @@
                 {% consent_button result True %}
                 {% if result.consent_model_obj %}
                     {% if result.consent.is_eligible %}
-
-                        {% if result.antenatal_enrollment_model_obj %}
-                            {% if result.antenatal_enrollment_model_obj.is_eligible %}
-                                {% locator_button result %}
-                                {% if result.locator_model_obj %}
-                                    {% dashboard_button result %}
-                                {% endif %}
-                            {% else %}
-                                {% eligibility_button result.antenatal_enrollment %}
-                            {% endif %}
-                        {% else %}
-                            {% antenatal_enrollment_button result %}
+                        {% locator_button result %}
+                        {% if result.locator_model_obj %}
+                            {% dashboard_button result %}
                         {% endif %}
-                    {% else %}
-                        {% eligibility_button result.consent %}
                     {% endif %}
+                {% else %}
+                    {% eligibility_button result.consent %}
                 {% endif %}
             {% else %}
                 {% eligibility_button result %}
@@ -61,7 +53,8 @@
 
     <td>{{ result.screening_identifier }} </td>
     <td>{{ result.consent.subject_identifier }}</td>
-    <td nowrap>{% age_in_years result.consent_model_obj.dob %}yrs {{ result.consent_model_obj.dob|date:"SHORT_DATE_FORMAT" }}</td>
+    <td nowrap>{% age_in_years result.consent_model_obj.dob %}yrs
+        {{ result.consent_model_obj.dob|date:"SHORT_DATE_FORMAT" }}</td>
     <td nowrap>{{ result.user_created }}</td>
     <td nowrap>{{ result.object.modified|date:"SHORT_DATETIME_FORMAT" }}</td>
 

--- a/flourish_dashboard/templates/flourish_dashboard/screening/maternal_listboard.html
+++ b/flourish_dashboard/templates/flourish_dashboard/screening/maternal_listboard.html
@@ -37,8 +37,6 @@
                             {% dashboard_button result %}
                         {% endif %}
                     {% endif %}
-                {% else %}
-                    {% eligibility_button result.consent %}
                 {% endif %}
             {% else %}
                 {% eligibility_button result %}

--- a/flourish_dashboard/templatetags/flourish_dashboard_extras.py
+++ b/flourish_dashboard/templatetags/flourish_dashboard_extras.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlencode, unquote
+from urllib.parse import unquote, urlencode
 
 from django import template
 from django.apps import apps as django_apps
@@ -7,6 +7,9 @@ from django.urls.base import reverse
 from django.utils.safestring import mark_safe
 from edc_base.utils import age, get_utcnow
 from edc_visit_schedule.models import SubjectScheduleHistory
+
+from flourish_dashboard.utils import flourish_dashboard_utils
+
 register = template.Library()
 
 
@@ -77,14 +80,17 @@ def huu_match_child_dashboard_button(subject_identifier):
 @register.inclusion_tag('flourish_dashboard/buttons/eligibility_button.html')
 def eligibility_button(model_wrapper):
     comment = []
-    obj = model_wrapper.object
+    eligible = []
+    objs = model_wrapper.object.screeningpregwomeninline_set.all()
     tooltip = None
-    if obj.ineligibility:
-        comment = obj.ineligibility[1:-1].split(',')
-        comment = list(set(comment))
-        comment.sort()
-    return dict(eligible=obj.is_eligible, comment=comment,
-                tooltip=tooltip, obj=obj)
+    for obj in objs:
+        if not obj.is_eligible:
+            comment = obj.ineligibility[1:-1].split(',')
+            comment = list(set(comment))
+            comment.sort()
+        eligible.append(obj.is_eligible)
+    return dict(eligible=any(eligible), comment=comment,
+                tooltip=tooltip, obj=objs)
 
 
 @register.inclusion_tag(
@@ -141,11 +147,21 @@ def edit_maternal_dataset_button(model_wrapper):
 
 @register.inclusion_tag('flourish_dashboard/buttons/screening_button.html')
 def screening_button(model_wrapper):
-    return dict(
-        add_screening_href=model_wrapper.maternal_screening.href,
-        screening_identifier=model_wrapper.object.screening_identifier,
-        maternal_screening_obj=model_wrapper.screening_model_obj,
-        caregiver_locator_obj=model_wrapper.locator_model_obj)
+    options = {}
+    if hasattr(model_wrapper, 'maternal_screening'):
+        options = dict(
+            add_screening_href=model_wrapper.maternal_screening.href,
+            screening_identifier=model_wrapper.object.screening_identifier,
+            maternal_screening_obj=model_wrapper.screening_model_obj,
+            caregiver_locator_obj=model_wrapper.locator_model_obj)
+    else:
+        options = dict(
+            add_screening_href=model_wrapper.href,
+            screening_identifier=model_wrapper.object.screening_identifier,
+            maternal_screening_obj=model_wrapper.object,
+            caregiver_locator_obj=model_wrapper.locator_model_obj)
+
+    return options
 
 
 @register.inclusion_tag(
@@ -161,33 +177,25 @@ def bhp_prior_screening_button(model_wrapper):
 @register.inclusion_tag(
     'flourish_dashboard/buttons/antenatal_enrollment_button.html')
 def antenatal_enrollment_button(model_wrapper):
-    title = ['subject antenatal enrollment.']
-    preg_screening_cls = django_apps.get_model(
-        'flourish_caregiver.screeningpregwomen')
-    try:
-        preg_screening_obj = preg_screening_cls.objects.get(
-            screening_identifier=model_wrapper.consent.screening_identifier)
-    except preg_screening_cls.DoesNotExist:
-        preg_screening_obj = None
-
+    title = ['Child Antenatal Enrollment(s)']
+    unsaved = any(
+        instance.id is None for instance in model_wrapper.antenatal_enrollments)
     return dict(
-        subject_identifier=model_wrapper.consent.subject_identifier,
-        add_anternatal_enrollment_href=model_wrapper.antenatal_enrollment.href,
-        antenatal_enrollment_model_obj=model_wrapper.antenatal_enrollment_model_obj,
-        screening_identifier=model_wrapper.object.screening_identifier,
-        preg_screening_obj=preg_screening_obj,
+        wrapped_antenatal_enrollments=model_wrapper.antenatal_enrollments,
+        unsaved=unsaved,
         title=' '.join(title), )
 
 
 @register.inclusion_tag(
     'flourish_dashboard/buttons/maternal_delivery_button.html')
 def maternal_delivery_button(model_wrapper):
-    title = ['subject maternal delivery.']
+    title = ['subject maternal deliveries.']
+    unsaved = any(
+        instance.id is None for instance in model_wrapper.maternal_deliveries)
+
     return dict(
-        subject_identifier=model_wrapper.object.subject_identifier,
-        add_maternal_delivery_href=model_wrapper.maternal_delivery.href,
-        maternal_delivery_model_obj=model_wrapper.maternal_delivery_model_obj,
-        maternal_ultrasound_initial_obj=model_wrapper.maternal_ultrasound_initial_obj,
+        wrapped_maternal_deliveries=model_wrapper.maternal_deliveries,
+        unsaved=unsaved,
         title=' '.join(title), )
 
 
@@ -443,51 +451,13 @@ def caregiver_child_consent_button(model_wrapper):
         title=' '.join(title))
 
 
-def is_delivery_window(subject_identifier):
-    maternal_delivery_cls = django_apps.get_model(
-        'flourish_caregiver.maternaldelivery')
-
-    preg_screen_cls = django_apps.get_model(
-        'flourish_caregiver.screeningpregwomen')
-
-    try:
-        preg_screen_cls.objects.get(subject_identifier=subject_identifier)
-    except preg_screen_cls.DoesNotExist:
-        return False
-    else:
-        try:
-            maternal_delivery_obj = maternal_delivery_cls.objects.get(
-                subject_identifier=subject_identifier)
-        except maternal_delivery_cls.DoesNotExist:
-            return True
-        else:
-            return ((get_utcnow().date() -
-                     maternal_delivery_obj.delivery_datetime.date()).days <= 3)
-
-
-def requires_child_version(subject_identifier, screening_identifier):
-    caregiver_child_consent_cls = django_apps.get_model(
-        'flourish_caregiver.caregiverchildconsent')
-
-    consent_version_cls = django_apps.get_model(
-        'flourish_caregiver.flourishconsentversion')
-    try:
-        consent_version_obj = consent_version_cls.objects.get(
-            screening_identifier=screening_identifier)
-    except consent_version_cls.DoesNotExist:
-        return False
-    else:
-        return (is_delivery_window(subject_identifier)
-                and not consent_version_obj.child_version)
-
-
 @register.inclusion_tag(
     'flourish_dashboard/buttons/consent_version_button.html')
 def consent_version_button(model_wrapper):
     title = ['Add Consent Version.']
 
     return dict(
-        requires_child_version=requires_child_version(
+        requires_child_version=flourish_dashboard_utils.requires_child_version(
             model_wrapper.object.subject_identifier,
             model_wrapper.object.screening_identifier),
         consent_versioned=model_wrapper.flourish_consent_version,
@@ -544,6 +514,7 @@ def child_death_report_button(model_wrapper):
         subject_identifier=model_wrapper.subject_identifier
     )
 
+
 @register.inclusion_tag('flourish_dashboard/buttons/tb_consent_button.html')
 def tb_consent_button(model_wrapper):
     title = ['TB Consent']
@@ -560,8 +531,8 @@ def tb_consent_button(model_wrapper):
 def young_adult_locator_button(model_wrapper):
     title = 'Young Adult Locator'
     return dict(
-        wrapper = model_wrapper,
-        title = title
+        wrapper=model_wrapper,
+        title=title
     )
 
 
@@ -617,28 +588,26 @@ def pre_flourish_birth_data_button(model_wrapper):
         add_pf_birth_data_href=model_wrapper.pf_birth_data.href,
         title=' '.join(title))
 
+
 @register.inclusion_tag('flourish_dashboard/buttons/facet_screening_button.html')
 def facet_screening_button(model_wrapper):
-
-
-    title  = 'FACET Screening'
+    title = 'FACET Screening'
     status = 'btn-success' if model_wrapper.facet_screening_obj else 'btn-warning'
-    
+
     return dict(
-        facet_screening_obj = model_wrapper.facet_screening_obj,
-        facet_screening_wrapper = model_wrapper.facet_screening_wrapper,
-        title = title,
-        status = status )
+        facet_screening_obj=model_wrapper.facet_screening_obj,
+        facet_screening_wrapper=model_wrapper.facet_screening_wrapper,
+        title=title,
+        status=status)
 
 
 @register.inclusion_tag('flourish_dashboard/buttons/facet_consent_button.html')
 def facet_consent_button(model_wrapper):
-
-    title  = 'FACET Consent'
+    title = 'FACET Consent'
     status = 'btn-success' if model_wrapper.facet_consent_obj else 'btn-warning'
-    
+
     return dict(
-        facet_consent_obj = model_wrapper.facet_consent_obj,
-        facet_consent_wrapper = model_wrapper.facet_consent_wrapper,
-        title = title,
-        status = status)
+        facet_consent_obj=model_wrapper.facet_consent_obj,
+        facet_consent_wrapper=model_wrapper.facet_consent_wrapper,
+        title=title,
+        status=status)

--- a/flourish_dashboard/templatetags/flourish_dashboard_extras.py
+++ b/flourish_dashboard/templatetags/flourish_dashboard_extras.py
@@ -57,8 +57,7 @@ def get_age(context, born=None):
         return age_str
 
 
-@register.inclusion_tag(
-    'flourish_dashboard/buttons/child_dashboard_button.html')
+@register.inclusion_tag('flourish_dashboard/buttons/child_dashboard_button.html')
 def child_dashboard_button(model_wrapper):
     child_dashboard_url = settings.DASHBOARD_URL_NAMES.get(
         'child_dashboard_url')
@@ -67,8 +66,7 @@ def child_dashboard_button(model_wrapper):
         subject_identifier=model_wrapper.subject_identifier)
 
 
-@register.inclusion_tag(
-    'pre_flourish/buttons/heu_dashboard_button.html')
+@register.inclusion_tag('pre_flourish/buttons/heu_dashboard_button.html')
 def huu_match_child_dashboard_button(subject_identifier):
     child_dashboard_url = settings.DASHBOARD_URL_NAMES.get(
         'pre_flourish_child_dashboard_url')

--- a/flourish_dashboard/utils.py
+++ b/flourish_dashboard/utils.py
@@ -1,3 +1,4 @@
+from django.apps import apps as django_apps
 from edc_base.utils import age, get_utcnow
 
 
@@ -10,6 +11,48 @@ class FlourishDashboardUtils:
             child_age = age(birth_date, get_utcnow())
             years = round(child_age.years + (child_age.months / 12), 2)
         return years if years else 0
+
+    def is_delivery_window(self, subject_identifier):
+
+        maternal_delivery_cls = django_apps.get_model(
+            'flourish_caregiver.maternaldelivery')
+
+        preg_screen_cls = django_apps.get_model(
+            'flourish_caregiver.screeningpregwomen')
+
+        try:
+            screen_obj = preg_screen_cls.objects.get(
+                subject_identifier=subject_identifier)
+        except preg_screen_cls.DoesNotExist:
+            return False
+        else:
+            is_delivery_window = []
+            for obj in screen_obj.screeningpregwomeninline_set.all():
+                try:
+                    maternal_delivery_obj = maternal_delivery_cls.objects.get(
+                        subject_identifier=subject_identifier,
+                        child_subject_identifier=obj.child_subject_identifier
+                    )
+                except maternal_delivery_cls.DoesNotExist:
+                    is_delivery_window.append(True)
+                else:
+                    is_delivery_window.append(
+                        (get_utcnow().date() -
+                         maternal_delivery_obj.delivery_datetime.date()).days <= 3)
+            return any(is_delivery_window)
+
+    def requires_child_version(self, subject_identifier, screening_identifier):
+
+        consent_version_cls = django_apps.get_model(
+            'flourish_caregiver.flourishconsentversion')
+        try:
+            consent_version_obj = consent_version_cls.objects.get(
+                screening_identifier=screening_identifier)
+        except consent_version_cls.DoesNotExist:
+            return False
+        else:
+            return (self.is_delivery_window(subject_identifier)
+                    and not consent_version_obj.child_version)
 
 
 flourish_dashboard_utils = FlourishDashboardUtils()

--- a/flourish_dashboard/utils.py
+++ b/flourish_dashboard/utils.py
@@ -54,5 +54,18 @@ class FlourishDashboardUtils:
             return (self.is_delivery_window(subject_identifier)
                     and not consent_version_obj.child_version)
 
+    def screening_object_by_child_pid(self, screening_identifier,
+                                      child_subject_identifier):
+        screening_model_cls = django_apps.get_model(
+            'flourish_caregiver.screeningpregwomen')
+        try:
+            screening_obj = screening_model_cls.objects.get(
+                screening_identifier=screening_identifier)
+        except screening_model_cls.DoesNotExist:
+            return None
+        else:
+            return screening_obj.screeningpregwomeninline_set.filter(
+                child_subject_identifier=child_subject_identifier)
+
 
 flourish_dashboard_utils = FlourishDashboardUtils()

--- a/flourish_dashboard/views/child_subject/dashboard/dashboard_view.py
+++ b/flourish_dashboard/views/child_subject/dashboard/dashboard_view.py
@@ -119,7 +119,7 @@ class ChildBirthValues(object):
         try:
 
             return self.maternal_delivery_cls.objects.get(
-                subject_identifier=self.caregiver_subject_identifier)
+                child_subject_identifier=self.subject_identifier)
         except ObjectDoesNotExist:
             return None
 

--- a/flourish_dashboard/views/maternal_subject/dashboard/dashboard_view.py
+++ b/flourish_dashboard/views/maternal_subject/dashboard/dashboard_view.py
@@ -52,12 +52,15 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
     mother_infant_study = True
     infant_links = True
     maternal_links = False
-    special_forms_include_value = 'flourish_dashboard/maternal_subject/dashboard/special_forms.html'
-    data_action_item_template = 'flourish_dashboard/maternal_subject/dashboard/data_manager.html'
-    infant_dashboard_include_value = 'flourish_dashboard/maternal_subject/dashboard/infant_dashboard_links.html'
+    special_forms_include_value = \
+        'flourish_dashboard/maternal_subject/dashboard/special_forms.html'
+    data_action_item_template = \
+        'flourish_dashboard/maternal_subject/dashboard/data_manager.html'
+    infant_dashboard_include_value = \
+        'flourish_dashboard/maternal_subject/dashboard/infant_dashboard_links.html'
     infant_subject_dashboard_url = 'child_dashboard_url'
-    antenatal_enrolment_model = 'flourish_caregiver.antenatalenrollment'
-    odk_archive_forms_include_value = 'flourish_dashboard/maternal_subject/dashboard/odk_archives.html'
+    odk_archive_forms_include_value = \
+        'flourish_dashboard/maternal_subject/dashboard/odk_archives.html'
 
     caregiver_child_consent_model = 'flourish_caregiver.caregiverchildconsent'
 
@@ -67,6 +70,13 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
     cohort_model = 'flourish_caregiver.cohort'
 
     child_dataset_model = 'flourish_child.childdataset'
+
+    screening_preg_model = 'flourish_caregiver.screeningpregwomen'
+
+    @property
+    def screening_preg_cls(self):
+        return django_apps.get_model(
+            'flourish_caregiver.screeningpregwomen')
 
     @property
     def schedule_history_cls(self):
@@ -90,20 +100,6 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
         return django_apps.get_model(self.tb_adol_assent_model)
 
     @property
-    def antenatal_enrolment_cls(self):
-        return django_apps.get_model(self.antenatal_enrolment_model)
-
-    @property
-    def antenatal_enrolment(self):
-        try:
-            antenatal_enrolment_obj = self.antenatal_enrolment_cls.objects.get(
-                subject_identifier=self.subject_identifier)
-        except self.antenatal_enrolment_cls.DoesNotExist:
-            return None
-        else:
-            return AntenatalEnrollmentModelWrapper(model_obj=antenatal_enrolment_obj)
-
-    @property
     def screening_pregnant_women(self):
         """Return a wrapped screening for preg women obj.
         """
@@ -115,7 +111,8 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
             # reused a wrapper because it already carry the object required
             # hence reducing errors
             subject_screening = screening_cls.objects.get(
-                screening_identifier=self.subject_consent_wrapper.object.screening_identifier)
+                screening_identifier=self.subject_consent_wrapper.object
+                .screening_identifier)
         except screening_cls.DoesNotExist:
             return None
         else:
@@ -160,7 +157,8 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
 
         for wrapped_child_consent in self.caregiver_child_consents:
             if wrapped_child_consent.caregiverchildconsent.id is None:
-                missing_child_version = wrapped_child_consent.caregiverchildconsent.version[0]
+                missing_child_version = \
+                    wrapped_child_consent.caregiverchildconsent.version[0]
                 break
 
         return missing_child_version
@@ -207,7 +205,7 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
         subject_identifier = self.kwargs.get('subject_identifier', None)
         child_subject_identifiers = self.caregiver_child_consent_cls.objects.filter(
             subject_consent__subject_identifier=subject_identifier).values_list(
-                'subject_identifier', flat=True).distinct()
+            'subject_identifier', flat=True).distinct()
         return list(set(child_subject_identifiers))
 
     @property
@@ -226,7 +224,8 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
         unexposed_adolencent = self.child_dataset_cls.objects.annotate(
             infant_hiv_exposed_lower=Lower('infant_hiv_exposed')
         ).filter(
-            infant_hiv_exposed_lower='unexposed', study_child_identifier__in=study_child_identifiers).count()
+            infant_hiv_exposed_lower='unexposed',
+            study_child_identifier__in=study_child_identifiers).count()
 
         return 25 >= unexposed_adolencent
 
@@ -234,7 +233,6 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
 
         if not self.subject_consent_wrapper.facet_screening_obj and \
                 self.subject_consent_wrapper.show_facet_screening:
-
             msg = mark_safe('This participant is eligible for the FACET Study')
 
             messages.add_message(self.request, messages.WARNING, msg)
@@ -244,11 +242,13 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
         if self.tb_adol_huu_limit_reached:
 
             children_age = [age(consent.object.child_dob, get_utcnow()).years
-                            for consent in self.caregiver_child_consents if consent.child_dob and
+                            for consent in self.caregiver_child_consents if
+                            consent.child_dob and
                             self.child_dataset_cls.objects.annotate(
-                infant_hiv_exposed_lower=Lower('infant_hiv_exposed')).filter(
-                study_child_identifier=consent.study_child_identifier,
-                infant_hiv_exposed_lower='unexposed').exists()]
+                                infant_hiv_exposed_lower=Lower(
+                                    'infant_hiv_exposed')).filter(
+                                study_child_identifier=consent.study_child_identifier,
+                                infant_hiv_exposed_lower='unexposed').exists()]
 
             age_adol_range = False
             for child_age in children_age:
@@ -272,8 +272,9 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
 
                 # if a model is deleted or does not exist, show the notification
                 if not tb_screening_exists:
-                    msg = mark_safe('Subject is eligible for TB Adolescent study, kindly complete'
-                                    'TB adol Screening form under special forms.')
+                    msg = mark_safe(
+                        'Subject is eligible for TB Adolescent study, kindly complete'
+                        'TB adol Screening form under special forms.')
                 elif not tb_consent_exists:
                     msg = mark_safe(
                         'Kindly complete TB adol Consent form under special forms.')
@@ -354,14 +355,13 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
             tb_adol_age=self.age_adol_range(self.consent_wrapped.child_age),
             tb_adol_eligibility=tb_adol_eligibility,
             tb_take_off_study=self.tb_take_off_study,
-            antenatal_enrolment=self.antenatal_enrolment,
             tb_adol_huu_limit_reached=self.tb_adol_huu_limit_reached)
         return context
 
     def age_adol_range(self, child_age):
 
         if child_age:
-            return child_age >= 10 and child_age <= 17
+            return 10 <= child_age <= 17
         return False
 
     @property
@@ -373,7 +373,8 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
 
         current_consent = wrapped_consents[0].consent if wrapped_consents else None
 
-        if current_consent and current_consent.id not in self.consents.values_list('id', flat=True):
+        if current_consent and current_consent.id not in self.consents.values_list(
+                'id', flat=True):
             wrapped_consents.append(current_consent)
 
         return (wrapped_consent for wrapped_consent in wrapped_consents)
@@ -389,7 +390,7 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
 
             return flourish_calendar_cls.objects.filter(
                 subject_identifier__in=self.child_subject_identifiers,
-                title='Follow Up',)
+                title='Follow Up', )
 
     @property
     def child_names_schedule_dict(self):
@@ -431,7 +432,7 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
             Q(subject_identifier__endswith='-35') | Q(
                 subject_identifier__endswith='-46') | Q(
                 subject_identifier__endswith='-56')).values_list(
-                    'subject_identifier', flat=True).distinct()
+            'subject_identifier', flat=True).distinct()
 
         return list(set(child_consents))
 
@@ -470,8 +471,9 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
                 self.current_onschedule_model = onschedule_model_obj
             else:
                 model_name = f'flourish_caregiver.{onschedule_model_obj._meta.model_name}'
-                visit_schedule, schedule = site_visit_schedules.get_by_onschedule_model_schedule_name(
-                    model_name, onschedule_model_obj.schedule_name)
+                visit_schedule, schedule = (
+                    site_visit_schedules.get_by_onschedule_model_schedule_name(
+                        model_name, onschedule_model_obj.schedule_name))
                 self.current_schedule = schedule
                 self.current_visit_schedule = visit_schedule
                 self.current_onschedule_model = onschedule_model_obj
@@ -504,7 +506,7 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
             MaternalVisitModelWrapper.model)
         subject_identifier = self.kwargs.get('subject_identifier')
         latest_visit = maternal_visit_cls.objects.filter(
-            subject_identifier=subject_identifier,).order_by(
+            subject_identifier=subject_identifier, ).order_by(
             '-report_datetime').first()
 
         if latest_visit:
@@ -550,18 +552,18 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
             return delivery_obj
 
     @property
-    def is_pregnant(self):
-        screening_preg_cls = django_apps.get_model(
-            'flourish_caregiver.screeningpregwomen')
-
+    def screening_preg_obj(self):
         if self.consent_wrapped:
             try:
-                screening_preg_cls.objects.get(
+                return self.screening_preg_cls.objects.get(
                     screening_identifier=self.consent_wrapped.screening_identifier)
-            except screening_preg_cls.DoesNotExist:
-                return False
-            else:
-                return False if self.delivery_obj else True
+            except self.screening_preg_cls.DoesNotExist:
+                return None
+
+    @property
+    def is_pregnant(self):
+        if self.consent_wrapped:
+            return False if self.delivery_obj and self.screening_preg_obj else True
 
     def get_assent_continued_consent_obj_or_msg(self):
         child_consents = self.caregiver_child_consents
@@ -570,7 +572,7 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
             child_age = ChildBirthValues(
                 subject_identifier=subject_identifier).get_difference(
                 birth_date=consent.object.child_dob)
-            
+
             self.get_assent_object_or_message(
                 subject_identifier=subject_identifier,
                 child_age=child_age,

--- a/flourish_dashboard/views/screening/maternal_screening_listboard_view.py
+++ b/flourish_dashboard/views/screening/maternal_screening_listboard_view.py
@@ -53,6 +53,13 @@ class MaternalScreeningListBoardView(NavbarViewMixin, EdcBaseViewMixin,
 
         return options
 
+    def get_wrapped_queryset(self, queryset):
+        qs = super().get_wrapped_queryset(queryset)
+        for obj in qs:
+            obj.is_eligible = obj.object.screeningpregwomeninline_set.filter(
+                is_eligible=True).exists()
+        return qs
+
     def extra_search_options(self, search_term):
         q = Q()
         if re.match('^[A-Z]+$', search_term):

--- a/flourish_dashboard/views/view_mixin/dashboard_view_mixin.py
+++ b/flourish_dashboard/views/view_mixin/dashboard_view_mixin.py
@@ -2,20 +2,19 @@ from django.apps import apps as django_apps
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.safestring import mark_safe
-from edc_base.utils import get_utcnow
-from edc_constants.constants import OFF_STUDY, NEW, POS
-from django.db.models import Q
 from edc_action_item.site_action_items import site_action_items
+from edc_base.utils import get_utcnow
+from edc_constants.constants import NEW, OFF_STUDY, POS
+
 from flourish_child.action_items import CHILDCONTINUEDCONSENT_STUDY_ACTION
-from flourish_child.action_items import YOUNG_ADULT_LOCATOR_ACTION
+from flourish_dashboard.utils import flourish_dashboard_utils
 
 
 class DashboardViewMixin:
-
     data_action_item_model = 'edc_data_manager.dataactionitem'
 
     young_adult_locator_model = 'flourish_child.youngadultlocator'
-    
+
     @property
     def young_adult_locator_cls(self):
         return django_apps.get_model(self.young_adult_locator_model)
@@ -29,13 +28,14 @@ class DashboardViewMixin:
 
         subject_identifier = self.kwargs.get('subject_identifier')
 
-        sub_study_visit_codes = ['2100T', '2200T', 
+        sub_study_visit_codes = ['2100T', '2200T',
                                  '2100A', '2200A', '2600F']
 
         offstudy_visit_obj = visit_cls.objects.filter(
             appointment__subject_identifier=subject_identifier,
-            study_status=OFF_STUDY).exclude(visit_code__in=sub_study_visit_codes).order_by(
-                'report_datetime').last()
+            study_status=OFF_STUDY).exclude(
+            visit_code__in=sub_study_visit_codes).order_by(
+            'report_datetime').last()
 
         trigger = self.require_offstudy(offstudy_visit_obj, subject_identifier)
 
@@ -76,7 +76,8 @@ class DashboardViewMixin:
             child_visit__subject_identifier=subject_identifier,
             hiv_test_result=POS)
 
-        return hiv_obj or preg_test_obj or offstudy_visit_obj or child_continued_consent_obj or infant_hiv_test_obj
+        return (hiv_obj or preg_test_obj or offstudy_visit_obj or
+                child_continued_consent_obj or infant_hiv_test_obj)
 
     def get_offstudy_message(self, offstudy_cls=None, msg=None):
 
@@ -149,7 +150,8 @@ class DashboardViewMixin:
             except assent_cls.DoesNotExist:
                 if version:
                     msg = mark_safe(
-                        f'Please complete the v{version} assent for child {subject_identifier}')
+                        f'Please complete the v{version} assent fo'
+                        f'r child {subject_identifier}')
                 else:
                     msg = mark_safe(
                         f'Please complete assent for child {subject_identifier}')
@@ -189,33 +191,10 @@ class DashboardViewMixin:
                     action_cls=child_continued_consent_cls,
                     action_type=CHILDCONTINUEDCONSENT_STUDY_ACTION)
                 msg = mark_safe(
-                    f'Please complete the continued consent for child {subject_identifier}.')
+                    f'Please complete the continued consent for child '
+                    f'{subject_identifier}.')
                 messages.add_message(self.request, messages.WARNING, msg)
             return obj
-        
-
-
-    def is_delivery_window(self, subject_identifier):
-
-        maternal_delivery_cls = django_apps.get_model(
-            'flourish_caregiver.maternaldelivery')
-
-        preg_screen_cls = django_apps.get_model(
-            'flourish_caregiver.screeningpregwomen')
-
-        try:
-            preg_screen_cls.objects.get(subject_identifier=subject_identifier)
-        except preg_screen_cls.DoesNotExist:
-            return False
-        else:
-            try:
-                maternal_delivery_obj = maternal_delivery_cls.objects.get(
-                    subject_identifier=subject_identifier)
-            except maternal_delivery_cls.DoesNotExist:
-                return True
-            else:
-                return ((get_utcnow().date() -
-                         maternal_delivery_obj.delivery_datetime.date()).days <= 3)
 
     def get_consent_from_version_form_or_message(self, subject_identifier,
                                                  screening_identifier):
@@ -239,10 +218,11 @@ class DashboardViewMixin:
 
                 if not caregiver_child_consent_objs:
                     msg = mark_safe(
-                        f'Please complete the v{consent_version_obj.child_version} consent '
+                        f'Please complete the v{consent_version_obj.child_version} '
+                        f'consent '
                         f'on behalf of child {subject_identifier}.')
                     messages.add_message(self.request, messages.WARNING, msg)
-            if (self.is_delivery_window(subject_identifier)
+            if (flourish_dashboard_utils.is_delivery_window(subject_identifier)
                     and not consent_version_obj.child_version):
                 msg = mark_safe(
                     'Please complete the consent version for consent on behalf of child'


### PR DESCRIPTION
…pport for ANC enrolledCaregiver

This commit addresses various changes to support the inclusion of multiple children to one caregiver in the Flourish Caregiver project. Child subject identifiers were added to antenatal screenings, ultra sounds, maternal deliveries and enrollment forms. The dashboard was updated to reflect the multi-child support. The addition of child subject identifiers aids in improving the tracking process, especially when handling multi-child scenarios. Lastly, print statements were removed for a cleaner codebase.