### PR TITLE
:ambulance: fix(Special Forms):Improve consent version validation in dashboard

### DIFF
--- a/flourish_dashboard/model_wrappers/antenatal_enrollment_wrapper_mixin.py
+++ b/flourish_dashboard/model_wrappers/antenatal_enrollment_wrapper_mixin.py
@@ -29,7 +29,7 @@ class AntenatalEnrollmentModelWrapperMixin:
     @property
     def antenatal_enrollments(self):
         wrapped_entries = []
-        if hasattr(self, 'consent_model_obj'):
+        if hasattr(self, 'consent_model_obj') and self.consent_model_obj is not None:
             caregiver_child_consents = (
                 self.consent_model_obj.caregiverchildconsent_set.all())
 

--- a/flourish_dashboard/templates/flourish_dashboard/buttons/consent_version_button.html
+++ b/flourish_dashboard/templates/flourish_dashboard/buttons/consent_version_button.html
@@ -1,11 +1,11 @@
  <a id="flourishconsentversion_add_{{ screening_identifier }}" 
  	title="{{ title }}"
  	
- 	{% if consent_versioned and not requires_child_version %}
+ 	{% if consent_versioned and not requires_child_version and is_latest_consent_version %}
             class="btn btn-success btn-sm" data-toggle="tooltip"  data-placement="right"
             href="{{ add_consent_version_href }}">
         {% else %}
-            class="btn btn-warning btn-sm" data-toggle="tooltip"  data-placement="right"
+            class="btn btn-warning btn-sm" data-toggle="tooltip" data-placement="right"
         href="{{ add_consent_version_href }}">
         {% endif %}
      	Consent Version

--- a/flourish_dashboard/templates/flourish_dashboard/maternal_subject/dashboard/special_forms.html
+++ b/flourish_dashboard/templates/flourish_dashboard/maternal_subject/dashboard/special_forms.html
@@ -12,7 +12,7 @@
         <td>{% caregiver_contact_button subject_consent %}</td>
     </tr>
     <tr>
-        <td>{% consent_version_button subject_consent %}</td>
+        <td>{% consent_version_button subject_consent is_latest_consent_version %}</td>
     </tr>
     {% if screening_preg_women %}
         <tr>

--- a/flourish_dashboard/templatetags/flourish_dashboard_extras.py
+++ b/flourish_dashboard/templatetags/flourish_dashboard_extras.py
@@ -66,15 +66,6 @@ def child_dashboard_button(model_wrapper):
         subject_identifier=model_wrapper.subject_identifier)
 
 
-@register.inclusion_tag('pre_flourish/buttons/heu_dashboard_button.html')
-def huu_match_child_dashboard_button(subject_identifier):
-    child_dashboard_url = settings.DASHBOARD_URL_NAMES.get(
-        'pre_flourish_child_dashboard_url')
-    return dict(
-        child_dashboard_url=child_dashboard_url,
-        subject_identifier=subject_identifier)
-
-
 @register.inclusion_tag('flourish_dashboard/buttons/eligibility_button.html')
 def eligibility_button(model_wrapper):
     comment = []

--- a/flourish_dashboard/templatetags/flourish_dashboard_extras.py
+++ b/flourish_dashboard/templatetags/flourish_dashboard_extras.py
@@ -451,7 +451,7 @@ def caregiver_child_consent_button(model_wrapper):
 
 @register.inclusion_tag(
     'flourish_dashboard/buttons/consent_version_button.html')
-def consent_version_button(model_wrapper):
+def consent_version_button(model_wrapper, is_latest_consent_version):
     title = ['Add Consent Version.']
 
     return dict(
@@ -461,6 +461,7 @@ def consent_version_button(model_wrapper):
         consent_versioned=model_wrapper.flourish_consent_version,
         screening_identifier=model_wrapper.object.screening_identifier,
         add_consent_version_href=model_wrapper.flourish_consent_version.href,
+        is_latest_consent_version=is_latest_consent_version,
         title=' '.join(title))
 
 

--- a/flourish_dashboard/views/maternal_subject/dashboard/dashboard_view.py
+++ b/flourish_dashboard/views/maternal_subject/dashboard/dashboard_view.py
@@ -312,6 +312,9 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
         self.get_consent_from_version_form_or_message(
             self.subject_identifier, self.subject_consent_wrapper.screening_identifier)
 
+        is_latest_consent_version = self.is_latest_consent_version(
+            self.subject_consent_wrapper.screening_identifier)
+
         self.get_offstudy_message(offstudy_cls=caregiver_offstudy_cls)
         if not self.tb_take_off_study:
             msg = 'Please complete the TB Off study form to take the subject Off study'
@@ -355,6 +358,7 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin,
             tb_adol_age=self.age_adol_range(self.consent_wrapped.child_age),
             tb_adol_eligibility=tb_adol_eligibility,
             tb_take_off_study=self.tb_take_off_study,
+            is_latest_consent_version = is_latest_consent_version,
             tb_adol_huu_limit_reached=self.tb_adol_huu_limit_reached)
         return context
 


### PR DESCRIPTION
Added a new parameter `is_latest_consent_version` to check if the user has the latest consent version before rendering the "Consent Version" button. This improves user interaction by making sure outdated versions are not used. Refactored the code in `dashboard_view_mixin.py` to improve readability and maintainability.


Redmine: https://redmine.bhp.org.bw/issues/7313
