### PR TITLE
refactor(Child Dashboard): Correct bracket placement in is_brain_ultrasound_enrolled function


### DIFF
--- a/flourish_dashboard/views/child_subject/dashboard/dashboard_view.py
+++ b/flourish_dashboard/views/child_subject/dashboard/dashboard_view.py
@@ -579,4 +579,4 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin, SubjectDashboardViewMi
     def is_brain_ultrasound_enrolled(self):
         """Returns True if the child is enrolled on the brain ultrasound schedule."""
         return (self.brain_ultrasound_helper.is_enrolled_brain_ultrasound() and
-                'brain_ultrasound') not in self.visit_schedules
+                'brain_ultrasound' not in self.visit_schedules)


### PR DESCRIPTION
Fixed a syntax error in is_brain_ultrasound_enrolled function of dashboard view in child_subject module. The misplaced bracket which led to inaccurate verification of whether 'brain_ultrasound' is not in visit_schedules has been corrected.