### PR TITLE
refactor(Child-dashboard): Update brain ultrasound enrollment checker in Flourish Child App



### DIFF
--- a/flourish_dashboard/views/child_subject/dashboard/dashboard_view.py
+++ b/flourish_dashboard/views/child_subject/dashboard/dashboard_view.py
@@ -579,4 +579,4 @@ class DashboardView(DashboardViewMixin, EdcBaseViewMixin, SubjectDashboardViewMi
     def is_brain_ultrasound_enrolled(self):
         """Returns True if the child is enrolled on the brain ultrasound schedule."""
         return (self.brain_ultrasound_helper.is_enrolled_brain_ultrasound() and
-                'brain_ultrasound' not in self.visit_schedules)
+                not self.brain_ultrasound_helper.is_onschedule)


### PR DESCRIPTION
The method to check if a child is enrolled in the brain ultrasound schedule has been refactored for improved logic. Instead of directly checking for 'brain_ultrasound' in the visit schedules, the function now uses the updated 'is_onschedule' from the helper class. This enhances data consistency and aids in easier management of schedule tracking.